### PR TITLE
Add config option for belt lantern underwater light behavior.

### DIFF
--- a/src/main/generated/assets/immersivelanterns/lang/en_us.json
+++ b/src/main/generated/assets/immersivelanterns/lang/en_us.json
@@ -3,5 +3,6 @@
   "immersivelanterns.configuration.Enable Lantern Swinging Physics": "Enable Lantern Swinging Physics",
   "immersivelanterns.configuration.Lantern Bounciness": "Lantern Bounciness",
   "immersivelanterns.configuration.Left-Handed Lanterns": "Left-Handed Lanterns",
+  "immersivelanterns.configuration.Water Sensitive Belt Light": "Water Sensitive Belt Light",
   "immersivelanterns.configuration.client": "client"
 }

--- a/src/main/java/toni/immersivelanterns/foundation/config/CClient.java
+++ b/src/main/java/toni/immersivelanterns/foundation/config/CClient.java
@@ -10,6 +10,7 @@ public class CClient extends ConfigBase {
     public final ConfigBool backLanterns = b(false, "Back Lanterns", "Whether lantern accessories should switch to the back of the player or not.");
     public final ConfigBool enablePhysics = b(true, "Enable Lantern Swinging Physics", "No performance impact, just cosmetic.");
     public final ConfigFloat bounciness = f(1f, 0.1f, 10f, "Lantern Bounciness", "How affected by in-world forces lantern physics should be. Default 1f");
+    public final ConfigBool waterSensitiveBeltLight = b(false, "Water Sensitive Belt Light", "When enabled, belt lantern dynamic light is extinguished while submerged in water.");
 
     @Override
     public String getName() {

--- a/src/main/java/toni/immersivelanterns/foundation/mixin/DynamicLightsMixin.java
+++ b/src/main/java/toni/immersivelanterns/foundation/mixin/DynamicLightsMixin.java
@@ -10,6 +10,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import toni.immersivelanterns.ImmersiveLanterns;
+import toni.immersivelanterns.foundation.config.AllConfigs;
 
 @Mixin(value = DynamicLightHandlers.class, remap = false)
 public class DynamicLightsMixin {
@@ -19,6 +20,6 @@ public class DynamicLightsMixin {
         DynamicLightHandlers.registerDynamicLightHandler(EntityType.PLAYER, DynamicLightHandler.makeHandler(player -> {
             var isEquipped = ImmersiveLanterns.isEquipped(player);
             return isEquipped ? 15 : 0;
-        }, player -> true));
+        }, player -> AllConfigs.client().waterSensitiveBeltLight.get()));
     }
 }


### PR DESCRIPTION
Expose "Water Sensitive Belt Light" in client config (default false) and wire the Sodium Dynamic Lights player handler to read it instead of always treating belt lanterns as water-sensitive.